### PR TITLE
add support to create asingle security group using a port range

### DIFF
--- a/update_security_groups_lambda/README.md
+++ b/update_security_groups_lambda/README.md
@@ -6,7 +6,10 @@ with the CloudFront IP range changes.
 
 ## Security Group
 
-This Lambda function updates EC2 security groups tagged with `Name: cloudfront` and `AutoUpdate: true` and a `Protocol` tag with value `http` or `https`.
+This Lambda function updates EC2 security groups tagged with 
+..*    `Name: cloudfront` and 
+..*    `AutoUpdate: true` and a
+..*    `Protocol` tag with value `http` or `https` or `PortRange` tag with value `80-443`
 
 
 ## Event Source


### PR DESCRIPTION
Creating multiple security groups for HTTP and HTTPS use 2 of the 5 available security groups on EC2 resources.  This pull requests adds the ability to use a single SG again by opening a port range from 80-443.  Yes, this opens more ports than necessary, but it is listing CloudFront IP addresses, so we're narrowing the scope to those IPs.  This is especially useful for placement on Load Balancers which also only listen on the listener ports, reducing the risk of openning the ports between 80 and 443.